### PR TITLE
removed tkinter and sqlite3, as they both are part of standard librar…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-tkinter
-sqlite3
 matplotlib


### PR DESCRIPTION
…y and need no installation

**Brief Description of Fix** 
  - `tkinter` and `sqlite3` were added in `requirements.txt` file, and since they are already available in standard library, hence the method of installation of requirements was getting failed. 

**Detailed Description including steps taken and any changes made**
Removed both of the from `requirements.txt`, and working fine


